### PR TITLE
Downgrade dependencies' versions to fix the broken UI icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
-    "jquery": "^3.4.0",
+    "jquery": "^2.2.4",
     "jquery-slider": "^0.0.1",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
@@ -36,6 +36,6 @@
     "vue-loader": "^12.1.0",
     "vue-template-compiler": "^2.3.3",
     "webpack": "^2.6.1",
-    "webpack-dev-server": "^3.1.11"
+    "webpack-dev-server": "^2.11.5"
   }
 }


### PR DESCRIPTION
The last update of dependencies jQuery and web-dev-server were breaking user
 interface. So, it was decided to downgrade to last non-major version of these 
dependencies to avoid the broke interface and try to fix the vulnerabilities
pointed by the GitHub.