### PR TITLE
Fix direction of arrows for Accordion's collapsed states

### DIFF
--- a/src/components/kytos/accordion/AccordionItem.vue
+++ b/src/components/kytos/accordion/AccordionItem.vue
@@ -106,11 +106,11 @@ export default {
 
   &[type=checkbox]
     & + .k-accordion-label:after
-      content: "▾"
+      content: "▸"
 
   &[type=checkbox]:checked
     & + .k-accordion-label:after
-      content: "▴"
+      content: "▾"
 
 .compacted
  .k-toolbar


### PR DESCRIPTION
Updated accordion arrows direction from this:
![Screenshot_2020-10-09 Kytos SDN Platform - Administrative Interface(1)](https://user-images.githubusercontent.com/17555995/95539561-14606100-09c5-11eb-8c2d-261c63bb4f11.png)

to this:
![Screenshot_2020-10-09 Kytos SDN Platform - Administrative Interface](https://user-images.githubusercontent.com/17555995/95539593-26da9a80-09c5-11eb-9bba-66fad37b6282.png)

