### PR TITLE
InfoPanel Toggle with events to communicate between components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Kytos/UI
 
+This is the web user interface for the [Kytos project](https://kytos.io). For more information
+on how to use it, please refer to the [UI documentation](https://docs.kytos.io/developer/web-ui/).
+
 ## Build Setup
 
-``` bash
+```bash
 # install dependencies
 npm install
 
@@ -19,7 +22,7 @@ To create a new release file you need to run the command below and during the
 procedure to create a new release on github you need append the file
 latest.zip.
 
-``` bash
+```bash
 # build for production and compress the file as latest.zip
 npm run build
 ```

--- a/src/components/kytos/map/Map.vue
+++ b/src/components/kytos/map/Map.vue
@@ -120,4 +120,6 @@ export default {
     height: 100%;
     z-index: 1;
 
+.mapboxgl-ctrl-attrib
+  top: -25px
 </style>

--- a/src/components/kytos/misc/InfoPanel.vue
+++ b/src/components/kytos/misc/InfoPanel.vue
@@ -1,14 +1,17 @@
 <template>
   <section v-bind:class="classObject" v-hotkey="keymap" v-show="this.infoPanelView">
-   <div class="k-info-title">
-    <icon v-if="myIcon" v-bind:name="myIcon"></icon>
-    <div v-if="myTitle" class="panel-title">
-      <h1>{{myTitle}} <small v-if="mySubtitle">{{mySubtitle}}</small></h1>
+    <div class="row" style="display: flex;justify-content: flex-end;">
+      <k-button class='close-info-panel-btn' tooltip="Close Info-Panel" icon="times" :on_click="this.hide"></k-button>
     </div>
-   </div>
-   <div class="k-info-wrapper">
-    <component v-bind:is="this.infoPanelView" v-bind:content="content"></component>
-   </div>
+    <div class="k-info-title">
+      <icon v-if="myIcon" v-bind:name="myIcon"></icon>
+      <div v-if="myTitle" class="panel-title">
+        <h1>{{ myTitle }} <small v-if="mySubtitle">{{ mySubtitle }}</small></h1>
+      </div>
+    </div>
+    <div class="k-info-wrapper">
+      <component v-bind:is="this.infoPanelView" v-bind:content="content"></component>
+    </div>
   </section>
 </template>
 
@@ -29,18 +32,19 @@ export default {
   mixins: [KytosBaseWithIcon],
   props: {
     subtitle: {
-        type: String,
+      type: String,
     },
   },
-  data () {
+  data() {
     return {
-      display: false,
       infoPanelView: undefined,
       content: undefined,
       myIcon: 'gear',
       myTitle: '',
       mySubtitle: '',
       maximized: false,
+      lastContent: {},
+      nothinShow: true,
       classObject: {
         'k-info-panel': true,
         'k-info-panel-max': false
@@ -48,12 +52,16 @@ export default {
     }
   },
   methods: {
-    toggle () {
+    toggle() {
       return
     },
-    hide () {
+    hide() {
       this.infoPanelView = undefined
       this.content = undefined
+
+      if (!this.nothinShow) {
+        this.$kytos.$emit('toggleInfoPanelIcon', 'hide')
+      }
     },
     /**
      * Show the Info Panel displayed in the right.
@@ -68,15 +76,31 @@ export default {
      *                          **icon**: "desktop"
      *                         }
      */
-    show (content) {
+    show(content) {
+      this.lastContent = content
       this.infoPanelView = content.component
       this.content = content.content
       this.myTitle = content.title
       this.mySubtitle = content.subtitle
       this.myIcon = content.icon
-      this.classObject['k-info-panel-max'] =  content.maximized
+      this.classObject['k-info-panel-max'] = content.maximized
+
+      this.nothinShow = false
+      this.$kytos.$emit('toggleInfoPanelIcon', 'show')
     },
-    register_listeners () {
+    latestContent() {
+      if (!this.nothinShow) {
+        this.show(this.lastContent)
+      } else {
+        let notification = {
+          icon: 'desktop',
+          title: 'Error: No InfoPanel to Display',
+          description: 'Please try to input a valid InfoPanel'
+        }
+        this.$kytos.$emit('setNotification', notification)
+      }
+    },
+    register_listeners() {
       /**
        * Hide the info panel displayed in the right.
        *
@@ -92,17 +116,26 @@ export default {
        * @type {Object} An content to be displayed by InfoPanel.
        */
       this.$kytos.$on('showInfoPanel', this.show)
+
+      /**
+       * Show the latest info panel called in the right,
+       * event to comunicate with tabs.vue
+       *
+       * @event showLatestInfoPanel
+       * @type {NULL}
+       */
+      this.$kytos.$on('showLatestInfoPanel', this.latestContent)
     }
   },
   computed: {
-    keymap () {
+    keymap() {
       return {
         'ctrl+alt+space': this.toggle,
         'esc': this.hide,
       }
     }
   },
-  mounted: function() {
+  mounted: function () {
     this.register_listeners()
   },
 }
@@ -117,51 +150,55 @@ export default {
   min-width: 900px !important
 
 .k-info-panel
- -webkit-order: 4
- -ms-flex-order: 4
- order: 4
- display: flex
- flex-direction: column
- min-height: 100%
- padding: 10px
- position: fixed
- right: 0
- top: 0
- background-color: $fill-panel
- width: 420px
- z-index: 999
- box-shadow: 10px 0px 20px 5px rgba(0, 0, 0, 0.4)
+  -webkit-order: 4
+  -ms-flex-order: 4
+  order: 4
+  display: flex
+  flex-direction: column
+  min-height: calc(100% - 45px)
+  padding: 10px
+  position: fixed
+  right: 0
+  top: 0
+  background-color: $fill-panel
+  width: 420px
+  z-index: 999
+  box-shadow: 10px 0px 20px 5px rgba(0, 0, 0, 0.4)
 
 .k-info-wrapper
- -webkit-flex: 1 1 auto
- overflow-y: auto
- height: 0px
+  -webkit-flex: 1 1 auto
+  overflow-y: auto
+  height: 0px
 
 .k-info-title
- display: flex
- flex-direction: row
- align-items: center
+  display: flex
+  flex-direction: row
+  align-items: center
 
- svg
-  fill: $fill-icon
-  width: 50px
-  height: 50px
-  padding: 10px
-  margin-right: 5px
+  svg
+    fill: $fill-icon
+    width: 50px
+    height: 50px
+    padding: 10px
+    margin-right: 5px
 
- .panel-title
-  padding: 0
-  margin: 0
-  color: $fill-text
-
-  & > h1
-    font-size: 1.2em
-    font-weight: bold
+  .panel-title
+    padding: 0
+    margin: 0
     color: $fill-text
 
-  small
-    font-size: 0.7em
-    color: $fill-text
-    display: block
+    & > h1
+      font-size: 1.2em
+      font-weight: bold
+      color: $fill-text
+
+    small
+      font-size: 0.7em
+      color: $fill-text
+      display: block
+
+.close-info-panel-btn
+  position: absolute !important
+  background: inherit !important
 
 </style>

--- a/src/components/kytos/tabs/tabs.vue
+++ b/src/components/kytos/tabs/tabs.vue
@@ -10,11 +10,15 @@
 
       <div class="k-tabs-control">
         <a class="k-hidden-tab" v-on:click="this.toggleTerminal">
-            <icon v-if="!hiddenTabs" name="chevron-down"></icon>
-            <icon v-else name="chevron-up"></icon>
+          <icon v-if="!hiddenTabs" name="chevron-down"></icon>
+          <icon v-else name="chevron-up"></icon>
+        </a>
+        <a class="k-hidden-tab k-toggle-info-panel" v-on:click="this.latestInfoPanel ">
+          <icon v-if="!hiddenPanel" name="chevron-left"></icon>
+          <icon v-else name="chevron-right"></icon>
         </a>
         <a v-on:click="this.fullTerminal">
-            <icon name="arrows-alt"></icon>
+          <icon name="arrows-alt"></icon>
         </a>
       </div><!-- .k-tabs-control -->
 
@@ -44,51 +48,60 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 export default {
   name: 'k-tabs',
   mixins: [KytosBaseWithIcon],
-  data () {
+  data() {
     return {
       hiddenTabs: true,
+      hiddenPanel: true,
+      content: {},
     }
   },
 
   methods: {
-    toggleTerminal () {
+    toggleTerminal() {
       this.hiddenTabs = !this.hiddenTabs
     },
+    toggleInfoPanelIcon(action) {
+      (action == 'show') ? this.hiddenPanel = false : this.hiddenPanel = true
+    },
+    latestInfoPanel() {
+      let infoPanelEvent
+      (this.hiddenPanel) ? infoPanelEvent = 'showLatestInfoPanel' : infoPanelEvent = 'hideInfoPanel'
+      this.$kytos.$emit(infoPanelEvent)
+    },
+    fullTerminal() {
 
-   fullTerminal () {
+      // Open/show tab on click
+      this.hiddenTabs = false;
 
-    // Open/show tab on click
-    this.hiddenTabs = false;
+      var isInFullScreen = (document.fullscreenElement && document.fullscreenElement !== null) ||
+          (document.webkitFullscreenElement && document.webkitFullscreenElement !== null) ||
+          (document.mozFullScreenElement && document.mozFullScreenElement !== null) ||
+          (document.msFullscreenElement && document.msFullscreenElement !== null);
 
-    var isInFullScreen = (document.fullscreenElement && document.fullscreenElement !== null) ||
-        (document.webkitFullscreenElement && document.webkitFullscreenElement !== null) ||
-        (document.mozFullScreenElement && document.mozFullScreenElement !== null) ||
-        (document.msFullscreenElement && document.msFullscreenElement !== null);
+      var docElm = document.getElementById("tabs-panel");
 
-    var docElm = document.getElementById("tabs-panel");
-
-    if (!isInFullScreen) {
+      if (!isInFullScreen) {
         if (docElm.requestFullscreen) {
-            docElm.requestFullscreen();
+          docElm.requestFullscreen();
         } else if (docElm.mozRequestFullScreen) {
-            docElm.mozRequestFullScreen();
+          docElm.mozRequestFullScreen();
         } else if (docElm.webkitRequestFullScreen) {
-            docElm.webkitRequestFullScreen();
+          docElm.webkitRequestFullScreen();
         } else if (docElm.msRequestFullscreen) {
-            docElm.msRequestFullscreen();
+          docElm.msRequestFullscreen();
         }
-    } else {
+      } else {
         if (document.exitFullscreen) {
-            document.exitFullscreen();
+          document.exitFullscreen();
         } else if (document.webkitExitFullscreen) {
-            document.webkitExitFullscreen();
+          document.webkitExitFullscreen();
         } else if (document.mozCancelFullScreen) {
-            document.mozCancelFullScreen();
+          document.mozCancelFullScreen();
         } else if (document.msExitFullscreen) {
-            document.msExitFullscreen();
+          document.msExitFullscreen();
         }
       }
-   },
+    },
 
     openTab: function (tabName) {
       // Declare all variables
@@ -97,13 +110,13 @@ export default {
       // Get all elements with class="tabcontent" and hide them
       tabcontent = document.getElementsByClassName("tabcontent");
       for (i = 0; i < tabcontent.length; i++) {
-          tabcontent[i].style.display = "none";
+        tabcontent[i].style.display = "none";
       }
 
       // Get all elements with class="tab-nav" and remove the class "active"
       tablinks = document.getElementsByClassName("tab-nav");
       for (i = 0; i < tablinks.length; i++) {
-          tablinks[i].className = tablinks[i].className.replace(" active", "");
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
       }
 
       // TODO: Fix this active button
@@ -114,7 +127,19 @@ export default {
       // Open select tab on click
       this.hiddenTabs = false;
 
+    },
+    register_listeners() {
+      /**
+       * Toggle the InfoPanel icon
+       *
+       * @event toggleInfoPanelIcon
+       * @type {NULL}
+       */
+      this.$kytos.$on('toggleInfoPanelIcon', this.toggleInfoPanelIcon)
     }
+  },
+  mounted() {
+    this.register_listeners()
   }
 }
 </script>
@@ -124,12 +149,12 @@ export default {
 @import '../../../assets/styles/variables'
 
 .k-tabs
- height: 350px
- margin-top: -350px
- z-index: 900
- position: relative
- background: $fill-panel-dark
- margin-left: 280px
+  height: 350px
+  margin-top: -350px
+  z-index: 1000
+  position: relative
+  background: $fill-panel-dark
+  margin-left: 280px
 
 .k-tabs.hiddenTabs
   margin-top: -25px
@@ -153,24 +178,24 @@ export default {
   display: none
 
 .k-tabs-nav
- overflow: hidden
- height: 25px
- background-color: $fill-panel-dark
- box-shadow: 0 -5px 5px -5px $fill-bar
+  overflow: hidden
+  height: 25px
+  background-color: $fill-panel-dark
+  box-shadow: 0 -5px 5px -5px $fill-bar
 
 .k-tabs-nav button
- float: left
- color: $fill-icon
- border: none
- outline: none
- cursor: pointer
- font-size: 0.78em
- padding: 0 1.2em
- height: 25px
- margin: 0px
- transition: 0.3s
- background-color: $fill-panel-dark
- border-right: 1px solid $fill-panel
+  float: left
+  color: $fill-icon
+  border: none
+  outline: none
+  cursor: pointer
+  font-size: 0.78em
+  padding: 0 1.2em
+  height: 25px
+  margin: 0px
+  transition: 0.3s
+  background-color: $fill-panel-dark
+  border-right: 1px solid $fill-panel
 
 .k-tabs-nav button:hover
   color: $fill-icon-h
@@ -200,20 +225,20 @@ export default {
   padding: 0px 0px 0px
 
 .k-tabs-control
- float: right
- display: inline-flex
+  float: right
+  display: inline-flex
 
- svg
-  width: 8px
-  fill: $fill-icon
+  svg
+    width: 8px
+    fill: $fill-icon
 
- a
-  display: block
-  cursor: pointer
-  padding: 5px
+  a
+    display: block
+    cursor: pointer
+    padding: 5px
 
- a:hover svg
-  fill: $fill-icon-h
+  a:hover svg
+    fill: $fill-icon-h
 
 .k-tabs:-moz-full-screen .tabcontent
   height: auto
@@ -226,7 +251,12 @@ export default {
   max-height: 100vh
 
 .compacted
- .k-tabs
-   margin-left: 40px
+  .k-tabs
+    margin-left: 40px
+
+.k-hidden-tab
+  &.k-toggle-info-panel
+    svg
+      width: 6px
 
 </style>


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change
 
The infoPanel had no UI tool to be closed once it was open, so a button
is added in the right of the title and subtitle

![Screenshot_2020-11-10 Kytos SDN Platform - Administrative Interface(2)](https://user-images.githubusercontent.com/17555995/98697152-5af20400-2353-11eb-9a3c-ccc3490126d8.png)

Added a toggle inside the tabs for the infopanel and a quick css fix for mapboxgl-ctrl
that was being overlayed by the tabs was made too 

![Screenshot_2020-11-10 Kytos SDN Platform - Administrative Interface(1)](https://user-images.githubusercontent.com/17555995/98697251-79f09600-2353-11eb-8110-e72c542a529a.png)

Once added the toggle button, the infopanel was overlaying the tabs, so it could never
be reached compromising its new purpose

![Screenshot_2020-11-10 Kytos SDN Platform - Administrative Interface(3)](https://user-images.githubusercontent.com/17555995/98697500-c20fb880-2353-11eb-9af4-c4f2d88957d3.png)

For the tabs and InfoPanel to comunicate about wich state infopanel is now assuming, 
two new events were implemented  `showLatestInfoPanel` to persist the last content 
displayed and `toggleInfoPanelIcon` to toggle the new button of tabs

### :page_facing_up: Release Notes

- Close button added in the InfoPanel component 
- Resolved overlay between tabs and InfoPanel
- Toggle button for the info panel and css fix for mapboxgl-ctr 
