### PR TITLE
Change info-panel warning k-notification

### DIFF
--- a/src/components/kytos/misc/InfoPanel.vue
+++ b/src/components/kytos/misc/InfoPanel.vue
@@ -92,12 +92,12 @@ export default {
       if (this.hasContent) {
         this.show(this.lastContent)
       } else {
-        let notification = {
-          icon: 'desktop',
-          title: 'Error: No InfoPanel to Display',
-          description: 'Please try to input a valid InfoPanel'
+        let standard_infoPanel = {
+          component: 'search-hosts',
+          title: '',
+          icon: 'gear'
         }
-        this.$kytos.$emit('setNotification', notification)
+        this.show(standard_infoPanel)
       }
     },
     register_listeners() {


### PR DESCRIPTION

### :bookmark_tabs: Description of the Change

The team discussed displaying a standard info-panel instead of a warning
notification saying that didn't exist in any info-panel at the moment. And we
choose the first option.

### :page_facing_up: Release Notes
 - Changed display standard info-panel instead of a warning k-notification
