### PR TITLE
Fix layout and colors for `k-context-panel`

### DIFF
--- a/src/components/kytos/map/MapBoxSettings.vue
+++ b/src/components/kytos/map/MapBoxSettings.vue
@@ -1,19 +1,22 @@
 <template>
     <k-toolbar-item icon="desktop" tooltip="MapBox Settings">
-      <k-accordion>
-        <k-accordion-item title="Custom Labels">
-          <k-dropdown title="Switch Labels:" icon="circle-o" :options="switchLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'switch'}}"></k-dropdown>
-          <k-dropdown title="Interface Labels:" icon="plug" :options="interfaceLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'interface'}}"></k-dropdown>
-        </k-accordion-item>
-        <k-accordion-item title="Background">
-          <k-button-group>
-            <k-button tooltip="Map Background" icon="globe"></k-button>
-            <k-button tooltip="Image Background (disabled)" icon="photo" :is-disabled="true"></k-button>
-            <k-button tooltip="No Background" icon="window-close-o"></k-button>
-          </k-button-group>
-          <k-slider icon="adjust" :initial-value="mapOpacity" :action="emitMapOpacity"></k-slider>
-        </k-accordion-item>
-      </k-accordion>
+      <k-context-panel title_color="#554077" title="MapBox Settings" icon="gear">
+        <k-accordion>
+          <k-accordion-item title="Custom Labels">
+            <k-dropdown title="Switch Labels:" icon="circle-o" :options="switchLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'switch'}}"></k-dropdown>
+            <k-dropdown title="Interface Labels:" icon="plug" :options="interfaceLabels" :event="{name: 'topology-toggle-label', content: {node_type: 'interface'}}"></k-dropdown>
+          </k-accordion-item>
+
+          <k-accordion-item title="Background">
+            <k-button-group>
+              <k-button tooltip="Map Background" icon="globe"></k-button>
+              <k-button tooltip="Image Background (disabled)" icon="photo" :is-disabled="true"></k-button>
+              <k-button tooltip="No Background" icon="window-close-o"></k-button>
+            </k-button-group>
+            <k-slider icon="adjust" :initial-value="mapOpacity" :action="emitMapOpacity"></k-slider>
+          </k-accordion-item>
+        </k-accordion>
+      </k-context-panel>
     </k-toolbar-item>
 </template>
 

--- a/src/components/kytos/misc/ContextPanel.vue
+++ b/src/components/kytos/misc/ContextPanel.vue
@@ -49,10 +49,11 @@ export default {
   },
   computed: {
     style() {
-      let color
-      (this.title_color !== undefined) ? color = 'color:' + this.title_color : color = 'color: #CCC'
-
-      return color
+      if (this.title_color !== undefined) {
+        return 'color:' + this.title_color
+      } else {
+        return 'color: #CCC'
+      }
     }
   },
 }

--- a/src/components/kytos/misc/ContextPanel.vue
+++ b/src/components/kytos/misc/ContextPanel.vue
@@ -1,12 +1,14 @@
 <template>
-<section class="k-context-panel">
-  <icon v-if="icon" v-bind:name="icon"></icon>
-  <div v-if="title" class="pannel-title">
-    <h1>{{title}} <small>{{subtitle}}</small></h1>
-  </div>
-  <!--@slot Can be filled with the panel content -->
-  <slot />
-</section>
+  <section class="k-context-panel">
+    <div class="k-context-panel-title">
+      <icon v-if="icon" v-bind:name="icon"></icon>
+      <div v-if="title" class="pannel-title">
+        <h1 :style="style">{{ title }} <small>{{ subtitle }}</small></h1>
+      </div>
+    </div>
+    <!--@slot Can be filled with the panel content -->
+    <slot/>
+  </section>
 </template>
 
 <script>
@@ -15,14 +17,43 @@ import KytosBaseWithIcon from '../base/KytosBaseWithIcon';
 
 /**
  * Represents a context where the developer can add any desired content.
+ *
+ * @example:
+ * <k-context-panel title_color="#554077" subtitle="Some Subtitle" title="Some Title" icon="gear">
+ *     <any-k-component></any-k-component>
+ * </k-context-panel>
+ *
+ * @param {string} title: Title of the k-context-panel
+ * @param {string} title_color: Define custom color of the title
+ *                      ** Hexadecimal for non CSS standard colors, but it is strongly
+ *                         recommended the use of our kytos-colors. **
+ * @param {string} icon: Define custom icon to k-context-panel
+ * @param {string} subtitle: Subtitle of k-context-panel
  */
 export default {
   name: 'k-context-panel',
   mixins: [KytosBaseWithIcon],
   props: {
-    subtitle: {
-        type: String
+    title: {
+      type: String
     },
+    icon: {
+      type: String
+    },
+    subtitle: {
+      type: String
+    },
+    title_color: {
+      type: String
+    },
+  },
+  computed: {
+    style() {
+      let color
+      (this.title_color !== undefined) ? color = 'color:' + this.title_color : color = 'color: #CCC'
+
+      return color
+    }
   },
 }
 </script>
@@ -38,33 +69,37 @@ export default {
   background: $fill-panel
   max-height: 100vh
   width: 220px
-  margin-top: 40px
-  padding: 5px 10px
+  margin-bottom: 10px
   z-index: 99
   box-shadow: 10px 0px 20px -10px $fill-panel
-  color: red
-
-  > svg
-   vertical-align: middle
-   color: $fill-icon
 
   .pannel-title
-    padding: 5px 0
-    background: $fill-panel-h
-    height: 35px
+    background: inherit
+    text-transform: capitalize
 
-  > h1
-    font-size: 0.9em
-    line-height: 3em
-    font-weight: bold
-    float: left
-    color: $fill-text
+  .k-context-panel-title
+    display: flex
+    flex-direction: row
+    align-items: center
+    margin: 5px 0
+
+    > svg
+      vertical-align: middle
+      color: $fill-icon
+      width: 20px
+      height: 20px
+      margin-right: 5px
+
+    h1
+      font-size: 1em
+      font-weight: bold
 
   .pannel-title
     small
-      font-size: 0.5em
+      font-size: 0.65em
       font-weight: bold
-      margin: 0.5em
       color: $fill-text
+      display: block
+
 
 </style>


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

The k-context-panel needed an update in its template and an CSS fix to work
correctly and provide a better user experience. With this PR, the component
went from:

![Screenshot_2020-12-04 Kytos SDN Platform - Administrative Interface(3)](https://user-images.githubusercontent.com/17555995/101200297-dd18d400-3644-11eb-9342-84a6d5502bdb.png)

to this: 
![Screenshot_2020-12-04 Kytos SDN Platform - Administrative Interface(2)](https://user-images.githubusercontent.com/17555995/101198688-9aee9300-3642-11eb-87ca-52427aae9507.png)
 *the two components with different colors are just an example of the new feature*

The component still have its previous props as title, description and icon. The
new feature is that now the color of the title can be chosen by the user, what
can provide some visual change of context if the colors be well arranged.

Also, the  component is added to the MapBox Settings k-toolbar.

### :page_facing_up: Release Notes

- [ui] Update k-context-panel template component 
- [ui] Added k-context-panel new CSS styles 
