### PR TITLE
Added upward or downward sorter to the k-table

### DIFF
--- a/src/components/kytos/table/Table.vue
+++ b/src/components/kytos/table/Table.vue
@@ -7,12 +7,13 @@
           <th scope="col">#</th>
           <th scope="col" class="header" v-for="(header, index) in headers" @click="defineSort(index)">
             {{ header }}
-            <span v-if="currentSortDir[index] === 'desc'">▾</span>
-            <span v-else>▴</span>
+            <span class="order-dir" v-if="currentSort === index" >
+              {{ spanDir(index) }}
+            </span>
+            <span class="order-dir" v-else>&nbsp;</span>
           </th>
         </tr>
         </thead>
-
         <tbody>
         <tr v-for="(row, index) in rowsOfPage">
           <th scope="row" style="width: 45px">{{ rowIndex(index) }}</th>
@@ -141,9 +142,17 @@ export default {
         * this.currentSortDir[newSort] = sortDir
         */
       }
-
-      console.log(this.currentSortDir)
       this.currentSort = newSort;
+    },
+    spanDir(index) {
+      /**
+      * Defines a span marker only for the selected
+      * column to indicate its sort direction
+      */
+      if (this.currentSortDir[index] === 'desc')
+        return '▾'
+
+      return '▴'
     }
   },
   computed: {
@@ -268,5 +277,9 @@ export default {
 
 .k-table-divisor
   height: 190px
+
+.order-dir
+  display: inline-block
+  width: 12px
 
 </style>


### PR DESCRIPTION
### :bookmark_tabs: Description of the Change

This is a new feature for the k-table component, that allows the user to sort
the table just by clicking in a selected header, each click ordinates in ascendant
or descendant direction, which can be verified by the up and down arrows sided
in the headers title

![Screenshot_2021-01-06 Kytos SDN Platform - Administrative Interface(2)](https://user-images.githubusercontent.com/17555995/103785950-925ef300-501a-11eb-91db-0932442287a7.png)

### :page_facing_up: Release Notes
- Added upward or downward sorter to the k-table
